### PR TITLE
Optimization of CollisionObject::computeAABB()

### DIFF
--- a/include/fcl/collision_object.h
+++ b/include/fcl/collision_object.h
@@ -206,24 +206,16 @@ public:
     }
     else
     {
-      // TODO : see if it is possible to use directly the quaternion rotation
-      aabb.min_ = aabb.max_ = t.getTranslation();
       const Matrix3f& rot = t.getRotation();
       const AABB& aabb_local = cgeom->aabb_local;
-
-      for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
-          float e = rot(i, j) * aabb_local.min_[j];
-          float f = rot(i, j) * aabb_local.max_[j];
-          if(e < f) {
-            aabb.min_[i] += e;
-            aabb.max_[i] += f;
-          } else {
-            aabb.min_[i] += f;
-            aabb.max_[i] += e;
-          }
-        }
-      }
+      const Vec3f center = 0.5 * (aabb_local.max_ + aabb_local.min_);
+      const Vec3f halfSize = 0.5 * (aabb_local.max_ - aabb_local.min_);
+      const Vec3f newHalfSize(std::abs(rot(0, 0)) * halfSize[0] + std::abs(rot(0, 1)) * halfSize[1] + std::abs(rot(0, 2)) * halfSize[2],
+                              std::abs(rot(1, 0)) * halfSize[0] + std::abs(rot(1, 1)) * halfSize[1] + std::abs(rot(1, 2)) * halfSize[2],
+                              std::abs(rot(2, 0)) * halfSize[0] + std::abs(rot(2, 1)) * halfSize[1] + std::abs(rot(2, 2)) * halfSize[2]);
+      aabb.min_ = aabb.max_ = t.transform(center);
+      aabb.min_ -= newHalfSize;
+      aabb.max_ += newHalfSize;
 //      Vec3f center = t.transform(cgeom->aabb_center);
 //      Vec3f delta(cgeom->aabb_radius);
 //      aabb.min_ = center - delta;

--- a/include/fcl/collision_object.h
+++ b/include/fcl/collision_object.h
@@ -213,7 +213,7 @@ public:
       const Vec3f newHalfSize(std::abs(rot(0, 0)) * halfSize[0] + std::abs(rot(0, 1)) * halfSize[1] + std::abs(rot(0, 2)) * halfSize[2],
                               std::abs(rot(1, 0)) * halfSize[0] + std::abs(rot(1, 1)) * halfSize[1] + std::abs(rot(1, 2)) * halfSize[2],
                               std::abs(rot(2, 0)) * halfSize[0] + std::abs(rot(2, 1)) * halfSize[1] + std::abs(rot(2, 2)) * halfSize[2]);
-      aabb.min_ = aabb.max_ = t.transform(center);
+      aabb.min_ = aabb.max_ = rot * center + t.getTranslation(); // reuse cached rotation matrix to do transformation
       aabb.min_ -= newHalfSize;
       aabb.max_ += newHalfSize;
 //      Vec3f center = t.transform(cgeom->aabb_center);

--- a/test/test_fcl_collision.cpp
+++ b/test/test_fcl_collision.cpp
@@ -146,12 +146,6 @@ BOOST_AUTO_TEST_CASE(AABB_Rotate_test)
     timer.stop();
     std::cout << timer.getElapsedTime() << std::endl;
     
-    // Vec3f newcenter = t.transform(center);
-     // Vec3f delta(aabb_local.radius());
-     // AABB aabb4;
-     // aabb4.min_ = newcenter - delta;
-     // aabb4.max_ = newcenter + delta;
-     // std::cout << aabb4.min_ << aabb4.max_ << 0.5*(aabb4.min_ + aabb4.max_) << 0.5*(aabb4.max_ - aabb4.min_) << std::endl;
     for (int i = 0; i < N; ++i) {
         for (int xyz = 0; xyz < 3; ++xyz) {
             BOOST_TEST(problems[i].aabb.min_[xyz] == answer[i].min_[xyz], boost::test_tools::tolerance(1e-7));


### PR DESCRIPTION
improved performance of `CollisionObject::computeAABB()` by avoiding branching while keeping the number of arithmetics almost the same.

added unit test to confirm correspondence with brute force computation results. 26% performance improvement was observed on comparison with this unit test (compared 10 times averages).

before
```
$ ./test_fcl_collision --run_test=AABB_Rotate_test
Running 1 test case...
9.565

*** No errors detected
```

after
```
$ ./test_fcl_collision --run_test=AABB_Rotate_test
Running 1 test case...
7.386

*** No errors detected
```